### PR TITLE
#8: allow Svelte 4.x as peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "svelte-jester": "^2.1.5"
       },
       "peerDependencies": {
-        "svelte": "^3.5.0"
+        "svelte": ">=3.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "site-dev": "gulp site-dev"
   },
   "peerDependencies": {
-    "svelte": "^3.5.0"
+    "svelte": ">=3.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",


### PR DESCRIPTION
Updates the peer dependency to allow any Svelte version >= 3.5.0. Fixes #8 